### PR TITLE
Update Together referral links

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ## Cloning & running
 
 1. Fork or clone the repo
-2. Create an account at [Together AI](https://togetherai.link) for the LLM
+2. Create an account at [Together AI](https://togetherai.link/?utm_source=llamatutor&utm_medium=referral&utm_campaign=example-app) for the LLM
 3. Create an account at [Exa](https://exa.ai/)
 4. Create an account at [Helicone](https://www.helicone.ai/) for observability
 5. Create a `.env` (use the `.example.env` for reference) and replace the API keys

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -31,7 +31,7 @@ const Hero: FC<THeroProps> = ({
       <div className="mx-auto mt-10 flex max-w-3xl flex-col items-center justify-center sm:mt-36">
         <a
           className="mb-4 inline-flex h-7 shrink-0 items-center gap-[9px] rounded-[50px] border-[0.5px] border-solid border-[#E6E6E6] bg-[rgba(234,238,255,0.65)] bg-white px-5 py-4 shadow-[0px_1px_1px_0px_rgba(0,0,0,0.25)]"
-          href="https://togetherai.link/"
+          href="https://togetherai.link/?utm_source=llamatutor&utm_medium=referral&utm_campaign=example-app"
           target="_blank"
         >
           <Image


### PR DESCRIPTION
Updates direct Together AI marketing links to use the repo-specific example-app UTM referral URL.\n\nVerification:\n- Checked direct Together links only; docs/model/API-specific links were left unchanged.\n- Ran direct-link scanner for this repo.\n- Ran git diff --check.